### PR TITLE
Set CXX epoch test state based on CMake knowledge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,43 @@
-# Use cpp as language as tests relay on build small projects
+# Use cpp as language as tests rely on build small projects
 language: cpp
 
-# Can test on one each of Linux/macOS because support is mainly
-# across cmake versions (may need more as C++ standard support evolves)
+# Test across Linux/macOS
+# - Add g++-6 and 7 from ppa
+# Only 1 cmake version (may need more as C++ standard support evolves)
+# This gives x4 rows in the matrix, three linux, two macOS
 matrix:
   include:
     - os: linux
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
     - os: osx
       osx_image: xcode9
       compiler: clang
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
 
-# At least on mac, should have suitable CMake via Homebrew, but want to upgrade
-# to keep track of boost...
+# Configure the CC/CXX values
+before_install:
+  - eval "${MATRIX_EVAL}"
+
+# At least on mac, should have suitable CMake via Homebrew
 # On Linux, can grab CMake bundle, or use Docker, or use pullProducts
 install:
   - |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #   Though a very simple project, it requires its own functionality
 #   to install natively or using the CET/UPS policy
 cmake_minimum_required(VERSION 3.0)
-project(cetbuildtools2 VERSION 0.1.0 LANGUAGES C)
+project(cetbuildtools2 VERSION 0.1.0)
 
 # - Install policy
 # Native only for now

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -162,10 +162,20 @@ foreach(cxx_epoch IN ITEMS 11 14 17 2a)
             --build-options "-Dcetbuildtools2_MODULE_PATH=${PROJECT_SOURCE_DIR}/Modules" "-DCET_COMPILER_CXX_STANDARD=${cxx_epoch}" "-DEXPECTED_CXX_STD=${cxx_epoch}"
             --test-command ${CMAKE_CTEST_COMMAND} -VV
      )
-endforeach()
 
-# Should mark tests as failing if used compiler known to not support epoch?
-set_tests_properties(testCetConfigureCXXStandard_2a PROPERTIES WILL_FAIL TRUE)
+   # Check on expected pass/fail of test
+   # May need further special cases as/when additional compilers/cmake
+   # versions are supported.
+   if(NOT DEFINED CMAKE_CXX${cxx_epoch}_STANDARD_COMPILE_OPTION)
+     # CMake/Compiler doesn't know about this standard, test should fail
+     set_tests_properties(testCetConfigureCXXStandard_${cxx_epoch} PROPERTIES WILL_FAIL TRUE)
+   endif()
+
+   # Special case for GCC < 4.9: It does not report __cplusplus correctly
+   if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9) AND (cxx_epoch GREATER 11))
+     set_tests_properties(testCetConfigureCXXStandard_${cxx_epoch} PROPERTIES WILL_FAIL TRUE)
+   endif()
+endforeach()
 
 # Test that unknown min standard fails
 add_test(
@@ -181,6 +191,12 @@ add_test(
 set_tests_properties(testCetConfigureCXXStandard_invalidminimum PROPERTIES WILL_FAIL TRUE)
 
 # Test that a valid min standard is also the default standard
+if(DEFINED CMAKE_CXX14_STANDARD_COMPILE_OPTION)
+  set(_cxxmin 14)
+else()
+  set(_cxxmin 11)
+endif()
+
 add_test(
   NAME testCetConfigureCXXStandard_minimumisdefault
   COMMAND ${CMAKE_CTEST_COMMAND}
@@ -188,10 +204,11 @@ add_test(
           --build-generator ${CMAKE_GENERATOR}
           --build-makeprogram ${CMAKE_MAKE_PROGRAM}
           --build-config $<CONFIG>
-          --build-options "-Dcetbuildtools2_MODULE_PATH=${PROJECT_SOURCE_DIR}/Modules" "-DCET_COMPILER_CXX_STANDARD_MINIMUM=14" "-DEXPECTED_CXX_STD=14"
+          --build-options "-Dcetbuildtools2_MODULE_PATH=${PROJECT_SOURCE_DIR}/Modules" "-DCET_COMPILER_CXX_STANDARD_MINIMUM=${_cxxmin}" "-DEXPECTED_CXX_STD=${_cxxmin}"
           --test-command ${CMAKE_CTEST_COMMAND} -VV
   )
 
-
-
-
+# Special case for GCC < 4.9: It does not report __cplusplus correctly
+if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9))
+  set_tests_properties(testCetConfigureCXXStandard_minimumisdefault PROPERTIES WILL_FAIL TRUE)
+endif()

--- a/testing/testCetConfigureCXXStandard/test-cxxstd.cc
+++ b/testing/testCetConfigureCXXStandard/test-cxxstd.cc
@@ -7,9 +7,14 @@ int main() {
   // mark __cplusplus with that epoch
   if (__cplusplus == 201103L) {
     std::cout << "11\n";
-  } else if (__cplusplus == 201402L) {
+  }
+  // Compilers may mark C++14 partial support with intermediate numbers
+  else if ((__cplusplus > 201103L) && (__cplusplus <= 201402L)) {
     std::cout << "14\n";
-  } else if (__cplusplus > 201402L) {
+  }
+  // Anything greater than 14 should be partial or full C++17
+  // Actual ISO value TBD
+  else if (__cplusplus > 201402L) {
     std::cout << "17\n";
   } else {
     std::cout << "unsupported\n";


### PR DESCRIPTION
Cetbuildtools2 aims to support GCC and Clang from versions that support
C++11 at minimum. Tests that check configuration of C++ epoch support
assume that system *does* support all except the putative "2a".

Set C++ std epoch test pass/fail state based on running CMake's
knowledge. This simply confirms we are using that correctly. Further
selection of the pass/fail cases may be needed as/when further
compiler and CMake versions are supported.

Fixes: #7 