### PR TITLE
Supply FindBoost module for CMake<3.10

### DIFF
--- a/Modules/FindBoost.cmake
+++ b/Modules/FindBoost.cmake
@@ -1,0 +1,85 @@
+#.rst:
+# FindBoost
+# ---------
+#
+# Find Boost include dirs and libraries
+#
+# This module reuses the core :cmake:module:`FindBoost module <cmake:module:FindBoost>`
+# for primary Boost location functionality and you should consult :cmake:module:`its documentation <cmake:module:FindBoost>`
+# for details of its main options, arguments and set variables and created imported targets.
+# This module does not change nor add to this interface.
+#
+# After using :cmake:module:`FindBoost <cmake:module:FindBoost>` to locate Boost, this
+# module creates imported targets for the Boost libraries if they do not exist. This
+# works around an issue in CMake versions < 3.11 where the targets are not created
+# if the found Boost version is not known to CMake. This was done to ensure link
+# dependencies between the Boost librarties are declared correctly, but prevented
+# easy use of new Boost versions before CMake itself was updated.
+#
+# Following the pattern adopted in CMake 3.11, this module creates the imported targets
+# for all versions of Boost when the client is running CMake < 3.11. Link dependencies
+# between Boost libraries are not declared, leaving it up to the client to link their
+# targets to all needed Boost targets. CET projects generally fully declare link interfaces,
+# so it is not expected this will cause an issue.
+#
+
+# Reproduce fundamental find of Boost
+include(${CMAKE_ROOT}/Modules/FindBoost.cmake)
+
+# Create binary imported targets if required
+if(Boost_FOUND AND (CMAKE_VERSION VERSION_LESS "3.11") AND (NOT _Boost_IMPORTED_TARGETS))
+  # Find boost will already have created Boost::boost for us.
+  foreach(COMPONENT ${Boost_FIND_COMPONENTS})
+    if(NOT TARGET Boost::${COMPONENT})
+      string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+      if(Boost_${UPPERCOMPONENT}_FOUND)
+        if(Boost_USE_STATIC_LIBS)
+          add_library(Boost::${COMPONENT} STATIC IMPORTED)
+        else()
+          # Even if Boost_USE_STATIC_LIBS is OFF, we might have static
+          # libraries as a result.
+          add_library(Boost::${COMPONENT} UNKNOWN IMPORTED)
+        endif()
+        if(Boost_INCLUDE_DIRS)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
+        endif()
+        if(EXISTS "${Boost_${UPPERCOMPONENT}_LIBRARY}")
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+            IMPORTED_LOCATION "${Boost_${UPPERCOMPONENT}_LIBRARY}")
+        endif()
+        if(EXISTS "${Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE}")
+          set_property(TARGET Boost::${COMPONENT} APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS RELEASE)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
+            IMPORTED_LOCATION_RELEASE "${Boost_${UPPERCOMPONENT}_LIBRARY_RELEASE}")
+        endif()
+        if(EXISTS "${Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG}")
+          set_property(TARGET Boost::${COMPONENT} APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS DEBUG)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "CXX"
+            IMPORTED_LOCATION_DEBUG "${Boost_${UPPERCOMPONENT}_LIBRARY_DEBUG}")
+        endif()
+        if(_Boost_${UPPERCOMPONENT}_DEPENDENCIES)
+          unset(_Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES)
+          foreach(dep ${_Boost_${UPPERCOMPONENT}_DEPENDENCIES})
+            list(APPEND _Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES Boost::${dep})
+          endforeach()
+          if(COMPONENT STREQUAL "thread")
+            list(APPEND _Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES Threads::Threads)
+          endif()
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${_Boost_${UPPERCOMPONENT}_TARGET_DEPENDENCIES}")
+        endif()
+        if(_Boost_${UPPERCOMPONENT}_COMPILER_FEATURES)
+          set_target_properties(Boost::${COMPONENT} PROPERTIES
+            INTERFACE_COMPILE_FEATURES "${_Boost_${UPPERCOMPONENT}_COMPILER_FEATURES}")
+        endif()
+      endif()
+    endif()
+  endforeach()
+endif()
+

--- a/documentation/find-modules/FindBoost.rst
+++ b/documentation/find-modules/FindBoost.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../Modules/FindBoost.cmake

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -22,6 +22,7 @@
    :hidden:
    :caption: Additional Find Modules
 
+   /find-modules/FindBoost
    /find-modules/FindCppUnit
    /find-modules/FindSQLite
    /find-modules/FindTBB

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -228,6 +228,26 @@ add_test(
           --build-options "-Dcetbuildtools2_MODULE_PATH=${PROJECT_SOURCE_DIR}/Modules" "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
   )
 
+# Boost imported targets workaround
+# On CMake < 3.11, FindBoost module won't generate imported targets for
+# unknown Boost versions, as it wants to fully define the dependencies
+# between them. From 3.11, imported targets will be generated for all known
+# libs, just without the link dependencies. This leaves it up to the user
+# to define closed set of links. In general, this is done anyway for CET
+# projects. To support older Cmake clients without patching, provide a workaround
+# to create imported targets on older cmakes.
+add_test(
+  NAME testFindBoostWorkaround
+  COMMAND ${CMAKE_CTEST_COMMAND}
+  --build-and-test ${CMAKE_CURRENT_LIST_DIR}/testFindBoostWorkaround ${CMAKE_CURRENT_BINARY_DIR}/testFindBoostWorkaround
+          --build-generator ${CMAKE_GENERATOR}
+          --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+          --build-config $<CONFIG>
+          --build-options "-Dcetbuildtools2_MODULE_PATH=${PROJECT_SOURCE_DIR}/Modules" "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+  )
+
+
+
 #-----------------------------------------------------------------------
 # Tests of cet_test
 # Basic

--- a/testing/testFindBoostWorkaround/CMakeLists.txt
+++ b/testing/testFindBoostWorkaround/CMakeLists.txt
@@ -1,0 +1,21 @@
+# - Basic project to test FindCppUnit
+cmake_minimum_required(VERSION 3.0)
+project(testFindBoostWorkaround)
+
+# Mock inclusion of cetbuildtools2)
+set(CMAKE_MODULE_PATH ${cetbuildtools2_MODULE_PATH})
+
+# Find without REQUIRED as tests may not always run on machine with Boost
+# Use Components that we know should have dependencies
+find_package(Boost COMPONENTS filesystem)
+
+if(Boost_FOUND)
+  # Check linking a basic target
+  add_executable(testBoostImportedTargets testBoostImportedTargets.cc)
+  target_link_libraries(testBoostImportedTargets PRIVATE Boost::filesystem)
+  add_test(NAME testBoostImportedTargets COMMAND testBoostImportedTargets)
+else()
+  message(WARNING "Boost not found, testFindBoostWorkaround not run...")
+endif()
+
+

--- a/testing/testFindBoostWorkaround/testBoostImportedTargets.cc
+++ b/testing/testFindBoostWorkaround/testBoostImportedTargets.cc
@@ -1,0 +1,8 @@
+#include <iostream>
+
+#include "boost/filesystem.hpp"
+
+int main(int argc, char* argv[]) {
+  std::cout << argv[0] << " " << boost::filesystem::file_size(argv[0]) << '\n';
+  return 0;
+}


### PR DESCRIPTION
In CMake versions prior to 3.11, the FindBoost module does not create
imprted targets for the Boost libraries if the detected Boost version
is not known to CMake. This prevents the use of new Boost versions
through imported targets until CMake updates FindBoost. CMake 3.11
now always creates imported targets, simply leaving link dependencies
undefined.

To assist cetbuildtools2 clients who may use older CMake versions,
provide a "wrapper" FindBoost module. Include the core FindBoost module
to locate Boost and set variables with an identical interface to the
core module. After finding Boost, create imported targets if required
using identical naming to core FindBoost to guarantee compatibility.

Implement test to check that workaround works now and in future.

Provide basic documentation for module, forwarding user to core
FindBoost docs for the majority of functionality.